### PR TITLE
Fix: Update profile image from hexagon to round design

### DIFF
--- a/style.css
+++ b/style.css
@@ -109,25 +109,23 @@ section:last-of-type {
 }
 
 #hero img {
-    width: 200px; /* Adjust size as needed */
+    width: 200px;
     height: 200px;
-    border-radius: 50%; /* Will be overridden by clip-path for hexagon */
+    border-radius: 50%; /* Perfect circle - no longer overridden */
     object-fit: cover;
     margin-top: 2rem;
-    border: 5px solid var(--accent-primary); /* Initial border */
-    box-shadow: 0 0 15px var(--accent-primary), 0 0 30px var(--accent-primary); /* Glowing effect */
-    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out; /* For hover effects */
-}
-
-/* Hexagonal frame for profile image */
-#hero img {
-    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
-    border-radius: 0; /* Reset border-radius for clip-path to work correctly */
+    border: 4px solid var(--accent-primary); /* Thin blue border */
+    box-shadow:
+        0 0 15px var(--accent-primary),
+        0 0 30px rgba(29, 161, 242, 0.3); /* Softer outer glow */
+    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
 }
 
 #hero img:hover {
-    transform: rotate(5deg) scale(1.05); /* Subtle rotation and scale */
-    box-shadow: 0 0 25px var(--accent-glow), 0 0 45px var(--accent-glow); /* Glow changes to accent secondary */
+    transform: scale(1.05); /* Clean scale, no rotation */
+    box-shadow:
+        0 0 25px var(--accent-primary),
+        0 0 45px rgba(29, 161, 242, 0.4);
     border-color: var(--accent-hover);
 }
 


### PR DESCRIPTION
- Removed hexagonal clip-path styling for the profile image.
- Updated #hero img to use border-radius: 50% for a circular shape.
- Applied a 4px solid blue border (var(--accent-primary)).
- Adjusted box-shadow for a softer glow effect.
- Updated #hero img:hover to a simple scale effect (transform: scale(1.05)) without rotation.
- Ensured hover box-shadow and border-color match the new design.

This change implements your requested circular profile image, enhancing the visual consistency and professional appearance of the hero section.