### PR TITLE
Add custom favicon links to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>0xWulf - Developer Portfolio</title>
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png">
     <!-- Link to CSS file will be added later -->
     <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
This commit updates the <head> section of index.html to include various favicon links, ensuring a professional and branded tab icon experience for you.

The following links have been added:
- Standard favicon.ico
- PNG favicons in sizes 16x16 and 32x32
- Apple touch icon (180x180)
- Android/Chrome icons (192x192 and 512x512)

All favicon files are referenced from the root directory as per the existing file structure. This resolves the issue of the browser displaying a default globe icon.