### PR TITLE
Fix: Resolve button overflow on project cards for mobile devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -636,6 +636,8 @@ section:last-of-type {
     text-decoration: none; /* Ensure no underline from default <a> */
     flex-grow: 1; /* Make buttons take equal width if desired */
     max-width: 48%; /* Ensure they don't overlap if flex-grow is too much */
+    box-sizing: border-box;
+    word-wrap: break-word;
 }
 
 .btn-primary {
@@ -680,6 +682,8 @@ section:last-of-type {
     }
     .project-card {
         padding: 1.5rem;
+        overflow: hidden;
+        box-sizing: border-box;
     }
     .project-card h3 {
         font-size: 1.5rem;
@@ -689,10 +693,15 @@ section:last-of-type {
     }
     .project-links {
         flex-direction: column; /* Stack buttons on mobile */
+        gap: 0.75rem;
+        margin-top: auto;
+        width: 100%;
     }
     .btn {
         width: 100%; /* Make buttons full width on mobile */
         max-width: 100%;
+        box-sizing: border-box;
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
This commit addresses an issue where "View Code" and "Try Live Demo" buttons on project cards were overflowing their containers on mobile viewports, such as the iPhone 13 Pro Max.

The following changes were made to `style.css`:

1.  **Mobile Styles (`@media (max-width: 768px)`):**
    *   Updated `.project-links` to ensure proper stacking and spacing:
        *   `gap: 0.75rem;`
        *   `margin-top: auto;`
        *   `width: 100%;`
    *   Updated `.btn` (mobile-specific) to include:
        *   `box-sizing: border-box;` (ensures padding is included in width)
        *   `margin: 0;` (removes potential overflow from margins)
    *   Updated `.project-card` (mobile-specific) to include:
        *   `overflow: hidden;` (prevents content from overflowing card boundaries)
        *   `box-sizing: border-box;`

2.  **General Button Styles (`.btn`):**
    *   Added `box-sizing: border-box;` to ensure consistent width calculation.
    *   Added `word-wrap: break-word;` to prevent long text from causing button overflow.

These changes ensure that project card buttons are correctly constrained within the card boundaries on mobile devices, maintaining a professional appearance and preventing horizontal scrolling.