### PR TITLE
Fix: Correct project card layout to 2x2 grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -574,6 +574,7 @@ section:last-of-type {
     flex-direction: column;
     transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
 }
 
 /* 3D tilt effect on hover with border glow - from issue */


### PR DESCRIPTION
The project cards in the 'Featured Projects' section were not consistently displaying in a 2x2 grid on wider screens. Specifically, the MarkdownMate card would sometimes appear on its own row.

This was caused by the `.project-card` class missing the `box-sizing: border-box;` property in its base style. Without it, the card's padding was added to its specified width, causing the cards to become too wide for the two-column grid layout defined by `grid-template-columns: repeat(2, minmax(320px, 1fr));`. This forced later cards onto new rows.

The fix involves adding `box-sizing: border-box;` to the main CSS rule for `.project-card`. This ensures that padding and borders are included in the element's total width and height, aligning with the grid track sizing.

The mobile layout (single column) already had this property within its media query and remains unaffected and correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout consistency for project cards by updating box-sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->