### PR TITLE
feat: add PiDeck project card to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,20 @@
                         <a href="https://keyjolt.dev" target="_blank" rel="noopener" class="btn btn-secondary">Try Live Demo</a>
                     </div>
                 </article>
+                <article class="project-card">
+                    <div class="project-icon"><span>🛠️</span></div>
+                    <h3>PiDeck</h3>
+                    <p class="project-description">
+                        Admin dashboard for managing Raspberry Pi 5 server. Centralized control hub for hosted apps and system metrics.
+                    </p>
+                    <p class="project-tech-stack">
+                        <strong>Tech:</strong> Node.js, Express, React, TailwindCSS, PostgreSQL
+                    </p>
+                    <div class="project-links">
+                        <a href="https://github.com/hexawulf/PiDeck" target="_blank" rel="noopener" class="btn btn-primary">View Code</a>
+                        <a href="https://pideck.piapps.dev" target="_blank" rel="noopener" class="btn btn-secondary">Try Live Demo</a>
+                    </div>
+                </article>
             </div>
         </section>
 


### PR DESCRIPTION
This commit introduces a new project card for PiDeck to the portfolio's index.html page. The card is added to the #projects section within the .projects-grid container, maintaining stylistic consistency with existing project entries.

The PiDeck project card includes:
- A distinctive 🛠️ emoji icon.
- Project title: PiDeck.
- Description: Admin dashboard for managing Raspberry Pi 5 server. Centralized control hub for hosted apps and system metrics.
- Tech stack: Node.js, Express, React, TailwindCSS, PostgreSQL.
- Links to the project's code repository and live demo.